### PR TITLE
Fix Database Setup (Installation) for Version 1.1

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -78,6 +78,8 @@
 				CREATE TABLE `tbl_fields_systemcreateddate` (
 					`id` int(11) unsigned NOT NULL auto_increment,
 					`field_id` int(11) unsigned NOT NULL,
+					`show_time` enum('yes','no') NOT NULL DEFAULT 'no',
+					`use_timeago` enum('yes','no') NOT NULL DEFAULT 'no',
 					PRIMARY KEY  (`id`),
 					KEY `field_id` (`field_id`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
@@ -86,6 +88,8 @@
 				CREATE TABLE `tbl_fields_systemmodifieddate` (
 					`id` int(11) unsigned NOT NULL auto_increment,
 					`field_id` int(11) unsigned NOT NULL,
+					`show_time` enum('yes','no') NOT NULL DEFAULT 'no',
+					`use_timeago` enum('yes','no') NOT NULL DEFAULT 'no',
 					PRIMARY KEY  (`id`),
 					KEY `field_id` (`field_id`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci


### PR DESCRIPTION
Adds database-fields for the new settings „show time“ and „use time ago“ to the installation process. Right now they are only included in the update process.